### PR TITLE
✨ Video transocding and hls.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Misc
 .DS_Store
 *.pem
-media
+media/*
+!media/.gitkeep
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Misc
 .DS_Store
 *.pem
+media
 
 # Logs
 logs

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@packages/common",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c ../../eslint.config.js"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^4.8.4"
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import fs from "fs";
+
+export const getMediaPath = (
+  relativePath: string,
+  options = { bundle: false },
+): string => {
+  const projectRoot = !options.bundle
+    ? path.resolve(__dirname, "../../..")
+    : path.resolve(__dirname, "../../../../../../../..");
+  const mediaPath = path.join(projectRoot, "media", relativePath);
+
+  return mediaPath;
+};
+
+export const ensureMediaPath = (filePath: string) => {
+  const mediaPath = getMediaPath(filePath);
+  fs.mkdirSync(mediaPath, { recursive: true });
+};

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "exclude": [],
+  "include": ["**/*.ts", "**/*.cjs", "**/*.mjs"]
+}

--- a/packages/transcode/package.json
+++ b/packages/transcode/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@packages/transcode",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c ../../eslint.config.js"
+  },
+  "dependencies": {
+    "@packages/common": "workspace:*",
+    "fluent-ffmpeg": "^2.1.2"
+  },
+  "devDependencies": {
+    "@types/fluent-ffmpeg": "^2.1.24",
+    "@types/node": "^18.0.0",
+    "typescript": "^4.8.4"
+  }
+}

--- a/packages/transcode/src/index.ts
+++ b/packages/transcode/src/index.ts
@@ -1,0 +1,90 @@
+import path from "path";
+import fs from "fs";
+import ffmpeg from "fluent-ffmpeg";
+import { getMediaPath, ensureMediaPath } from "@packages/common";
+
+interface TranscodeOptions {
+  masterPath: string;
+  inputPath: string;
+  outputPath: string;
+  name: string;
+  bandwidth: number;
+  resolution: string;
+  segmentDuration: number;
+}
+
+const transcode = (options: TranscodeOptions) => {
+  const outputDir = `${options.outputPath}/${options.name}`;
+  ensureMediaPath(outputDir);
+
+  const callback = () => {
+    fs.appendFileSync(
+      getMediaPath(options.masterPath),
+      `#EXT-X-STREAM-INF:BANDWIDTH=${options.bandwidth},RESOLUTION=${options.resolution}\n${options.name}/playlist.m3u8\n`,
+    );
+
+    console.log(`${options.name} transcoding finished`);
+  };
+
+  ffmpeg(getMediaPath(options.inputPath))
+    .outputOptions([
+      "-profile:v baseline",
+      "-level 3.0",
+      `-s ${options.resolution}`,
+      "-start_number 0",
+      `-hls_time ${options.segmentDuration}`,
+      "-hls_list_size 0",
+      "-f hls",
+    ])
+    .output(getMediaPath(`${outputDir}/playlist.m3u8`))
+    .on("end", callback)
+    .on("error", (err) => console.error("Error:", err))
+    .run();
+};
+
+interface PipelineOptions {
+  inputPath: string;
+}
+
+const pipeline = ({ inputPath }: PipelineOptions) => {
+  const baseFileName = path.basename(inputPath);
+  const baseDirName = path.dirname(inputPath);
+
+  const outputPath = `${baseDirName}/_${baseFileName}`;
+  ensureMediaPath(outputPath);
+
+  const masterPath = `${outputPath}/master.m3u8`;
+  fs.writeFileSync(getMediaPath(masterPath), "#EXTM3U\n");
+
+  transcode({
+    masterPath,
+    inputPath,
+    outputPath,
+    name: "360p",
+    resolution: "640x360",
+    bandwidth: 800000,
+    segmentDuration: 10,
+  });
+
+  transcode({
+    masterPath,
+    inputPath,
+    outputPath,
+    name: "720p",
+    resolution: "1280x720",
+    bandwidth: 2800000,
+    segmentDuration: 10,
+  });
+
+  transcode({
+    masterPath,
+    inputPath,
+    outputPath,
+    name: "1080p",
+    resolution: "1920x1080",
+    bandwidth: 5000000,
+    segmentDuration: 10,
+  });
+};
+
+void pipeline({ inputPath: "movies/the_yard.mp4" });

--- a/packages/transcode/tsconfig.json
+++ b/packages/transcode/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "exclude": [],
+  "include": ["**/*.ts", "**/*.cjs", "**/*.mjs"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,9 +9,12 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^0.3.11",
+    "@packages/common": "workspace:*",
     "@packages/config-server": "workspace:*",
     "@packages/db": "workspace:*",
+    "@packages/transcode": "workspace:*",
     "clsx": "^2.0.0",
+    "hls.js": "^1.4.13",
     "lucide-react": "^0.285.0",
     "next": "14.0.4",
     "next-auth": "^4.24.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,6 +15,7 @@
     "@packages/transcode": "workspace:*",
     "clsx": "^2.0.0",
     "hls.js": "^1.4.13",
+    "lodash.throttle": "^4.1.1",
     "lucide-react": "^0.285.0",
     "next": "14.0.4",
     "next-auth": "^4.24.5",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.0.4",
+    "@types/lodash.throttle": "^4.1.9",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
+    "react-use": "^17.4.2",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/packages/web/src/app/[type]/[name]/play/page.tsx
+++ b/packages/web/src/app/[type]/[name]/play/page.tsx
@@ -1,0 +1,17 @@
+import { Video } from "~/components";
+
+interface Props {
+  params: { type: string; name: string };
+}
+
+export default function Page({ params }: Props) {
+  const { type, name } = params;
+
+  return (
+    <main>
+      <Video.Player
+        src={`http://localhost:3000/api/stream/${type}/_${name}/master.m3u8`}
+      />
+    </main>
+  );
+}

--- a/packages/web/src/app/[type]/play/[name]/page.tsx
+++ b/packages/web/src/app/[type]/play/[name]/page.tsx
@@ -9,10 +9,10 @@ export default function Page({ params }: Props) {
   const { type, name } = params;
 
   return (
-    <VideoProvider>
-      <Video.Player
-        src={`http://localhost:3000/api/stream/${type}/_${name}/master.m3u8`}
-      />
+    <VideoProvider
+      src={`http://localhost:3000/api/stream/${type}/_${name}/master.m3u8`}
+    >
+      <Video.Player />
     </VideoProvider>
   );
 }

--- a/packages/web/src/app/[type]/play/[name]/page.tsx
+++ b/packages/web/src/app/[type]/play/[name]/page.tsx
@@ -1,3 +1,4 @@
+import { VideoProvider } from "~/providers";
 import { Video } from "~/components";
 
 interface Props {
@@ -8,10 +9,10 @@ export default function Page({ params }: Props) {
   const { type, name } = params;
 
   return (
-    <main>
+    <VideoProvider>
       <Video.Player
         src={`http://localhost:3000/api/stream/${type}/_${name}/master.m3u8`}
       />
-    </main>
+    </VideoProvider>
   );
 }

--- a/packages/web/src/app/api/stream/[...file]/route.ts
+++ b/packages/web/src/app/api/stream/[...file]/route.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import { NextResponse, type NextRequest } from "next/server";
+import { getMediaPath } from "@packages/common";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { file: string[] } },
+) {
+  try {
+    const mediaPath = getMediaPath(params.file.join("/"), { bundle: true });
+    const mediaUrl = new URL(mediaPath, request.nextUrl);
+    const extension = path.extname(mediaUrl.pathname);
+
+    const blob = fs.readFileSync(mediaPath);
+
+    let contentTypeHeader;
+
+    switch (extension) {
+      case ".m3u8":
+        contentTypeHeader = "application/vnd.apple.mpegurl";
+        break;
+      case ".ts":
+        contentTypeHeader = "video/MP2T";
+        break;
+      default:
+        contentTypeHeader = "application/octet-stream";
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", contentTypeHeader);
+
+    return new NextResponse(blob, { status: 200, statusText: "OK", headers });
+  } catch (e) {
+    console.error(`Error loading ${params.file.join("/")}`);
+    if (e instanceof Error) console.log(e.message);
+    return new NextResponse(null, { status: 404, statusText: "Not Found" });
+  }
+}

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -1,2 +1,3 @@
 export * as Layout from "./layout";
 export * as Auth from "./auth";
+export * as Video from "./video";

--- a/packages/web/src/components/layout/base.tsx
+++ b/packages/web/src/components/layout/base.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export const Base = ({ children }: Props) => {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <ThemeProvider
           attribute="class"

--- a/packages/web/src/components/video/controls/fullscreen.tsx
+++ b/packages/web/src/components/video/controls/fullscreen.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Expand, Shrink } from "lucide-react";
+import { useVideoContext } from "~/providers";
+
+export const Fullscreen = () => {
+  const { layoutRef } = useVideoContext();
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const handleFullscreenToggle = () => {
+    if (!layoutRef?.current) return;
+
+    if (!document.fullscreenElement) {
+      layoutRef.current.requestFullscreen().catch(() => {});
+    } else {
+      if (document.exitFullscreen) document.exitFullscreen();
+    }
+
+    setIsFullscreen((v) => !v);
+  };
+
+  return (
+    <button
+      onClick={handleFullscreenToggle}
+      title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+    >
+      {isFullscreen ? <Shrink size={30} /> : <Expand size={30} />}
+    </button>
+  );
+};

--- a/packages/web/src/components/video/controls/fullscreen.tsx
+++ b/packages/web/src/components/video/controls/fullscreen.tsx
@@ -1,28 +1,14 @@
 "use client";
 
-import { useState } from "react";
 import { Expand, Shrink } from "lucide-react";
 import { useVideoContext } from "~/providers";
 
 export const Fullscreen = () => {
-  const { layoutRef } = useVideoContext();
-  const [isFullscreen, setIsFullscreen] = useState(false);
-
-  const handleFullscreenToggle = () => {
-    if (!layoutRef?.current) return;
-
-    if (!document.fullscreenElement) {
-      layoutRef.current.requestFullscreen().catch(() => {});
-    } else {
-      if (document.exitFullscreen) document.exitFullscreen();
-    }
-
-    setIsFullscreen((v) => !v);
-  };
+  const { toggleFullscreen, isFullscreen } = useVideoContext();
 
   return (
     <button
-      onClick={handleFullscreenToggle}
+      onClick={toggleFullscreen}
       title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
     >
       {isFullscreen ? <Shrink size={30} /> : <Expand size={30} />}

--- a/packages/web/src/components/video/controls/index.tsx
+++ b/packages/web/src/components/video/controls/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useVideoContext } from "~/providers";
+import { cn } from "~/lib";
 import { Fullscreen } from "./fullscreen";
 import { Progress } from "./progress";
 import { PauseControl } from "./pause-control";
@@ -9,18 +11,26 @@ import { TimeCodes } from "./time-codes";
 import { Volume } from "./volume";
 
 export const Controls = () => {
+  const { isActive } = useVideoContext();
+
   return (
     <PauseControl>
       <div
-        className="absolute bottom-0 left-0 z-10 h-full w-full"
+        className="absolute bottom-0 left-0 z-10 h-full w-full transition-opacity duration-500 ease-in-out"
         style={{
-          backgroundImage: `linear-gradient(0deg, black 15%, transparent)`,
+          backgroundImage: `linear-gradient(0deg, black 1%, transparent)`,
+          opacity: isActive ? 1 : 0,
         }}
       >
         <div className="p-8 flex gap-2 flex-col justify-between items-center h-full">
           <div />
           <PauseIndicator />
-          <div className="w-full">
+          <div
+            className={cn(
+              "w-full transition-opacity duration-500 ease-in-out",
+              isActive ? "opacity-100" : "opacity-0",
+            )}
+          >
             <Progress />
             <div className="flex justify-between items-center px-4 pt-4">
               <div className="flex justify-start items-center gap-4">

--- a/packages/web/src/components/video/controls/index.tsx
+++ b/packages/web/src/components/video/controls/index.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Fullscreen } from "./fullscreen";
+import { Progress } from "./progress";
+import { PauseControl } from "./pause-control";
+import { PauseIndicator } from "./pause-indicator";
+import { Pause } from "./pause";
+import { TimeCodes } from "./time-codes";
+import { Volume } from "./volume";
+
+export const Controls = () => {
+  return (
+    <PauseControl>
+      <div
+        className="absolute bottom-0 left-0 z-10 h-full w-full"
+        style={{
+          backgroundImage: `linear-gradient(0deg, black 15%, transparent)`,
+        }}
+      >
+        <div className="p-8 flex gap-2 flex-col justify-between items-center h-full">
+          <div />
+          <PauseIndicator />
+          <div className="w-full">
+            <Progress />
+            <div className="flex justify-between items-center px-4 pt-4">
+              <div className="flex justify-start items-center gap-4">
+                <PauseControl>
+                  <Pause />
+                </PauseControl>
+                <TimeCodes />
+                <Volume />
+              </div>
+              <div>
+                <Fullscreen />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </PauseControl>
+  );
+};

--- a/packages/web/src/components/video/controls/pause-control.tsx
+++ b/packages/web/src/components/video/controls/pause-control.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import react from "react";
+import { useVideoContext } from "~/providers";
+
+interface Props {
+  children: React.ReactElement;
+}
+
+export const PauseControl = ({ children }: Props) => {
+  const { videoRef } = useVideoContext();
+
+  const togglePause = () => {
+    if (!videoRef?.current) return;
+
+    if (videoRef.current.paused) videoRef.current.play();
+    else videoRef.current.pause();
+  };
+
+  const child = react.cloneElement(children, { onClick: togglePause });
+
+  return <>{child}</>;
+};

--- a/packages/web/src/components/video/controls/pause-control.tsx
+++ b/packages/web/src/components/video/controls/pause-control.tsx
@@ -8,16 +8,9 @@ interface Props {
 }
 
 export const PauseControl = ({ children }: Props) => {
-  const { videoRef } = useVideoContext();
+  const { togglePlayPause } = useVideoContext();
 
-  const togglePause = () => {
-    if (!videoRef?.current) return;
-
-    if (videoRef.current.paused) videoRef.current.play();
-    else videoRef.current.pause();
-  };
-
-  const child = react.cloneElement(children, { onClick: togglePause });
+  const child = react.cloneElement(children, { onClick: togglePlayPause });
 
   return <>{child}</>;
 };

--- a/packages/web/src/components/video/controls/pause-indicator.tsx
+++ b/packages/web/src/components/video/controls/pause-indicator.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import { Pause as PauseIcon, Play as PlayIcon } from "lucide-react";
+import { useVideoContext } from "~/providers";
+import { cn } from "~/lib";
+
+export const PauseIndicator = () => {
+  const [paused, setPaused] = useState(true);
+  const { videoRef } = useVideoContext();
+
+  useEffect(() => {
+    if (!videoRef?.current) return;
+    const video = videoRef.current;
+
+    const handlePlay = () => setPaused(false);
+    const handlePause = () => setPaused(true);
+
+    if (video) {
+      video.addEventListener("play", handlePlay);
+      video.addEventListener("pause", handlePause);
+    }
+
+    return () => {
+      if (video) {
+        video.removeEventListener("play", handlePlay);
+        video.removeEventListener("pause", handlePause);
+      }
+    };
+  }, [videoRef]);
+
+  return (
+    <div
+      className={cn(
+        "bg-zinc-800 opacity-70 w-32 h-32 flex justify-center items-center rounded-full transition-all duration-100",
+        paused ? "opacity-70 scale-100" : "opacity-0 scale-0",
+      )}
+    >
+      {paused ? (
+        <PlayIcon size={50} fill="white" />
+      ) : (
+        <PauseIcon size={50} fill="white" />
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/video/controls/pause-indicator.tsx
+++ b/packages/web/src/components/video/controls/pause-indicator.tsx
@@ -1,40 +1,18 @@
-import { useState, useEffect } from "react";
 import { Pause as PauseIcon, Play as PlayIcon } from "lucide-react";
 import { useVideoContext } from "~/providers";
 import { cn } from "~/lib";
 
 export const PauseIndicator = () => {
-  const [paused, setPaused] = useState(true);
-  const { videoRef } = useVideoContext();
-
-  useEffect(() => {
-    if (!videoRef?.current) return;
-    const video = videoRef.current;
-
-    const handlePlay = () => setPaused(false);
-    const handlePause = () => setPaused(true);
-
-    if (video) {
-      video.addEventListener("play", handlePlay);
-      video.addEventListener("pause", handlePause);
-    }
-
-    return () => {
-      if (video) {
-        video.removeEventListener("play", handlePlay);
-        video.removeEventListener("pause", handlePause);
-      }
-    };
-  }, [videoRef]);
+  const { streamPaused } = useVideoContext();
 
   return (
     <div
       className={cn(
         "bg-zinc-800 opacity-70 w-32 h-32 flex justify-center items-center rounded-full transition-all duration-100",
-        paused ? "opacity-70 scale-100" : "opacity-0 scale-0",
+        streamPaused ? "opacity-70 scale-100" : "opacity-0 scale-0",
       )}
     >
-      {paused ? (
+      {streamPaused ? (
         <PlayIcon size={50} fill="white" />
       ) : (
         <PauseIcon size={50} fill="white" />

--- a/packages/web/src/components/video/controls/pause.tsx
+++ b/packages/web/src/components/video/controls/pause.tsx
@@ -1,34 +1,12 @@
-import { useState, useEffect } from "react";
 import { Pause as PauseIcon, Play as PlayIcon } from "lucide-react";
 import { useVideoContext } from "~/providers";
 
 export const Pause = () => {
-  const { videoRef } = useVideoContext();
-  const [paused, setPaused] = useState(true);
-
-  useEffect(() => {
-    if (!videoRef?.current) return;
-
-    const video = videoRef.current;
-    const handlePlay = () => setPaused(false);
-    const handlePause = () => setPaused(true);
-
-    if (video) {
-      video.addEventListener("play", handlePlay);
-      video.addEventListener("pause", handlePause);
-    }
-
-    return () => {
-      if (video) {
-        video.removeEventListener("play", handlePlay);
-        video.removeEventListener("pause", handlePause);
-      }
-    };
-  }, [videoRef]);
+  const { streamPaused } = useVideoContext();
 
   return (
-    <button className="p-2" title={paused ? "Play" : "Pause"}>
-      {paused ? (
+    <button className="p-2" title={streamPaused ? "Play" : "Pause"}>
+      {streamPaused ? (
         <PlayIcon size={40} fill="white" />
       ) : (
         <PauseIcon size={40} fill="white" />

--- a/packages/web/src/components/video/controls/pause.tsx
+++ b/packages/web/src/components/video/controls/pause.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { Pause as PauseIcon, Play as PlayIcon } from "lucide-react";
+import { useVideoContext } from "~/providers";
+
+export const Pause = () => {
+  const { videoRef } = useVideoContext();
+  const [paused, setPaused] = useState(true);
+
+  useEffect(() => {
+    if (!videoRef?.current) return;
+
+    const video = videoRef.current;
+    const handlePlay = () => setPaused(false);
+    const handlePause = () => setPaused(true);
+
+    if (video) {
+      video.addEventListener("play", handlePlay);
+      video.addEventListener("pause", handlePause);
+    }
+
+    return () => {
+      if (video) {
+        video.removeEventListener("play", handlePlay);
+        video.removeEventListener("pause", handlePause);
+      }
+    };
+  }, [videoRef]);
+
+  return (
+    <button className="p-2" title={paused ? "Play" : "Pause"}>
+      {paused ? (
+        <PlayIcon size={40} fill="white" />
+      ) : (
+        <PauseIcon size={40} fill="white" />
+      )}
+    </button>
+  );
+};

--- a/packages/web/src/components/video/controls/progress.tsx
+++ b/packages/web/src/components/video/controls/progress.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, type MouseEvent } from "react";
+import { useVideoContext } from "~/providers";
+
+export const Progress = () => {
+  const { videoRef } = useVideoContext();
+  const [progress, setProgress] = useState(0);
+  const [hoverProgress, setHoverProgress] = useState(0);
+  const [bufferProgress, setBufferProgress] = useState(0);
+
+  useEffect(() => {
+    if (!videoRef?.current) return;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    const updateProgress = () => {
+      const value = (video.currentTime / video.duration) * 100;
+      setProgress(value);
+
+      const bufferedRanges = video.buffered;
+      let maxBufferedEnd = 0;
+
+      for (let i = 0; i < bufferedRanges.length; i++) {
+        if (bufferedRanges.end(i) > maxBufferedEnd) {
+          maxBufferedEnd = bufferedRanges.end(i);
+        }
+      }
+
+      const bufferedValue = (maxBufferedEnd / video.duration) * 100;
+      setBufferProgress(bufferedValue);
+    };
+
+    video.addEventListener("timeupdate", updateProgress);
+
+    return () => {
+      if (video) video.removeEventListener("timeupdate", updateProgress);
+    };
+  }, [videoRef]);
+
+  const handleProgressBarClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (!videoRef?.current) return;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    const percent = e.nativeEvent.offsetX / e.currentTarget.offsetWidth;
+    video.currentTime = percent * video.duration;
+  };
+
+  const handleHover = (e: React.MouseEvent<HTMLDivElement>) => {
+    const boundingRect = e.currentTarget.getBoundingClientRect();
+    const mouseX = e.clientX - boundingRect.left;
+    const hoverWidth = (mouseX / boundingRect.width) * 100;
+    setHoverProgress(hoverWidth);
+  };
+
+  const handleMouseLeave = () => {
+    setHoverProgress(0);
+  };
+
+  return (
+    <div
+      className="bg-white relative h-2 hover:h-3 transition-height duration-200 ease-in-out w-full rounded-sm hover:cursor-pointer"
+      onClick={handleProgressBarClick}
+      onMouseMove={handleHover}
+      onDrag={handleHover}
+      onMouseLeave={handleMouseLeave}
+    >
+      <div
+        className="bg-zinc-300 h-full absolute rounded-sm"
+        style={{ width: `${bufferProgress}%` }}
+      />
+      <div
+        className="bg-zinc-400 h-full absolute rounded-sm"
+        style={{ width: `${hoverProgress}%` }}
+      />
+      <div
+        className="bg-red-500 h-full absolute rounded-sm"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+};

--- a/packages/web/src/components/video/controls/progress.tsx
+++ b/packages/web/src/components/video/controls/progress.tsx
@@ -1,41 +1,35 @@
 "use client";
 
-import { useState, type MouseEvent } from "react";
+import { useState } from "react";
 import { useVideoContext } from "~/providers";
 
 export const Progress = () => {
-  const { videoRef, streamCurrentPercent, streamBufferPercent } =
-    useVideoContext();
+  const {
+    progressBarRef,
+    streamCurrentPercent,
+    streamBufferPercent,
+    handleProgressBarDrag,
+  } = useVideoContext();
   const [hoverProgress, setHoverProgress] = useState(0);
 
-  const handleProgressBarClick = (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-
-    if (!videoRef?.current) return;
-    const video = videoRef.current;
-
-    const percent = e.nativeEvent.offsetX / e.currentTarget.offsetWidth;
-    video.currentTime = percent * video.duration;
-  };
-
-  const handleHover = (e: React.MouseEvent<HTMLDivElement>) => {
+  const updateVideoBufferTime = (e: React.MouseEvent<HTMLDivElement>) => {
     const boundingRect = e.currentTarget.getBoundingClientRect();
     const mouseX = e.clientX - boundingRect.left;
     const hoverWidth = (mouseX / boundingRect.width) * 100;
     setHoverProgress(hoverWidth);
   };
 
-  const handleMouseLeave = () => {
+  const resetVideoBufferTime = () => {
     setHoverProgress(0);
   };
 
   return (
     <div
       className="bg-white relative h-2 hover:h-3 transition-height duration-200 ease-in-out w-full rounded-sm hover:cursor-pointer"
-      onClick={handleProgressBarClick}
-      onMouseMove={handleHover}
-      onDrag={handleHover}
-      onMouseLeave={handleMouseLeave}
+      ref={progressBarRef}
+      onClick={handleProgressBarDrag}
+      onMouseMove={updateVideoBufferTime}
+      onMouseLeave={resetVideoBufferTime}
     >
       <div
         className="bg-zinc-300 h-full absolute rounded-sm"

--- a/packages/web/src/components/video/controls/progress.tsx
+++ b/packages/web/src/components/video/controls/progress.tsx
@@ -1,50 +1,18 @@
 "use client";
 
-import { useState, useEffect, type MouseEvent } from "react";
+import { useState, type MouseEvent } from "react";
 import { useVideoContext } from "~/providers";
 
 export const Progress = () => {
-  const { videoRef } = useVideoContext();
-  const [progress, setProgress] = useState(0);
+  const { videoRef, streamCurrentPercent, streamBufferPercent } =
+    useVideoContext();
   const [hoverProgress, setHoverProgress] = useState(0);
-  const [bufferProgress, setBufferProgress] = useState(0);
-
-  useEffect(() => {
-    if (!videoRef?.current) return;
-
-    const video = videoRef.current;
-    if (!video) return;
-
-    const updateProgress = () => {
-      const value = (video.currentTime / video.duration) * 100;
-      setProgress(value);
-
-      const bufferedRanges = video.buffered;
-      let maxBufferedEnd = 0;
-
-      for (let i = 0; i < bufferedRanges.length; i++) {
-        if (bufferedRanges.end(i) > maxBufferedEnd) {
-          maxBufferedEnd = bufferedRanges.end(i);
-        }
-      }
-
-      const bufferedValue = (maxBufferedEnd / video.duration) * 100;
-      setBufferProgress(bufferedValue);
-    };
-
-    video.addEventListener("timeupdate", updateProgress);
-
-    return () => {
-      if (video) video.removeEventListener("timeupdate", updateProgress);
-    };
-  }, [videoRef]);
 
   const handleProgressBarClick = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    if (!videoRef?.current) return;
 
+    if (!videoRef?.current) return;
     const video = videoRef.current;
-    if (!video) return;
 
     const percent = e.nativeEvent.offsetX / e.currentTarget.offsetWidth;
     video.currentTime = percent * video.duration;
@@ -71,7 +39,7 @@ export const Progress = () => {
     >
       <div
         className="bg-zinc-300 h-full absolute rounded-sm"
-        style={{ width: `${bufferProgress}%` }}
+        style={{ width: `${streamBufferPercent}%` }}
       />
       <div
         className="bg-zinc-400 h-full absolute rounded-sm"
@@ -79,7 +47,7 @@ export const Progress = () => {
       />
       <div
         className="bg-red-500 h-full absolute rounded-sm"
-        style={{ width: `${progress}%` }}
+        style={{ width: `${streamCurrentPercent}%` }}
       />
     </div>
   );

--- a/packages/web/src/components/video/controls/time-codes.tsx
+++ b/packages/web/src/components/video/controls/time-codes.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useVideoContext } from "~/providers";
 
 export const TimeCodes = () => {
-  const { videoRef } = useVideoContext();
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
+  const { streamCurrentTime, streamTotalTime } = useVideoContext();
 
-  const secondsToTime = (seconds: number | null) => {
+  const secondsToTimeCode = (seconds: number | null) => {
     if (!seconds) return "00:00:00";
 
     var date = new Date(0);
@@ -17,27 +14,10 @@ export const TimeCodes = () => {
     return date.toISOString().substr(11, 8);
   };
 
-  useEffect(() => {
-    if (!videoRef?.current) return;
-
-    const video = videoRef.current;
-    if (!video) return;
-
-    const updateProgress = () => {
-      setCurrentTime(video.currentTime);
-      setDuration(video.duration);
-    };
-
-    video.addEventListener("timeupdate", updateProgress);
-
-    return () => {
-      if (video) video.removeEventListener("timeupdate", updateProgress);
-    };
-  }, [videoRef]);
-
   return (
     <p className="whitespace-nowrap">
-      {secondsToTime(currentTime)} / {secondsToTime(duration)}
+      {secondsToTimeCode(streamCurrentTime)} /{" "}
+      {secondsToTimeCode(streamTotalTime)}
     </p>
   );
 };

--- a/packages/web/src/components/video/controls/time-codes.tsx
+++ b/packages/web/src/components/video/controls/time-codes.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useVideoContext } from "~/providers";
+
+export const TimeCodes = () => {
+  const { videoRef } = useVideoContext();
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  const secondsToTime = (seconds: number | null) => {
+    if (!seconds) return "00:00:00";
+
+    var date = new Date(0);
+
+    date.setSeconds(seconds);
+    return date.toISOString().substr(11, 8);
+  };
+
+  useEffect(() => {
+    if (!videoRef?.current) return;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    const updateProgress = () => {
+      setCurrentTime(video.currentTime);
+      setDuration(video.duration);
+    };
+
+    video.addEventListener("timeupdate", updateProgress);
+
+    return () => {
+      if (video) video.removeEventListener("timeupdate", updateProgress);
+    };
+  }, [videoRef]);
+
+  return (
+    <p className="whitespace-nowrap">
+      {secondsToTime(currentTime)} / {secondsToTime(duration)}
+    </p>
+  );
+};

--- a/packages/web/src/components/video/controls/volume.tsx
+++ b/packages/web/src/components/video/controls/volume.tsx
@@ -3,39 +3,31 @@ import { Volume2, VolumeX } from "lucide-react";
 import { useVideoContext } from "~/providers";
 
 export const Volume = () => {
-  const { videoRef } = useVideoContext();
-  const [volume, setVolume] = useState(1);
+  const { getStreamVolume, toggleVolume, changeVolume } = useVideoContext();
+
+  const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
-    if (!videoRef?.current) return;
-    videoRef.current.volume = volume;
-  }, [volume, videoRef]);
-
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    setVolume(Number(e.target.value));
-  };
-
-  const handleIconClick = (e: React.MouseEvent<SVGSVGElement>) => {
-    e.stopPropagation();
-    setVolume(volume === 0 ? 1 : 0);
-  };
+    setIsClient(true);
+  }, []);
 
   return (
     <div className="cursor-pointer flex gap-4 pl-3">
-      {volume > 0 ? (
-        <Volume2 className="cursor-pointer" onClick={handleIconClick} />
-      ) : (
-        <VolumeX className="cursor-pointer" onClick={handleIconClick} />
-      )}
+      <button
+        onClick={toggleVolume}
+        title={getStreamVolume() > 0 ? "Mute audio" : "Enable audio"}
+        suppressHydrationWarning
+      >
+        {isClient && getStreamVolume() > 0 ? <Volume2 /> : <VolumeX />}
+      </button>
       <input
         type="range"
         min="0"
         max="1"
         step="0.01"
-        value={volume}
-        onChange={handleVolumeChange}
-        className="appearance-none bg-transparent [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-zinc-300 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[10px] [&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-zinc-700 [&::-webkit-slider-thumb]:p-1"
+        value={getStreamVolume()}
+        onChange={changeVolume}
+        className="cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-zinc-300 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[10px] [&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-zinc-700 [&::-webkit-slider-thumb]:p-1"
         aria-label="Volume control"
         onClick={(e) => e.stopPropagation()}
       />

--- a/packages/web/src/components/video/controls/volume.tsx
+++ b/packages/web/src/components/video/controls/volume.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from "react";
+import { Volume2, VolumeX } from "lucide-react";
+import { useVideoContext } from "~/providers";
+
+export const Volume = () => {
+  const { videoRef } = useVideoContext();
+  const [volume, setVolume] = useState(1);
+
+  useEffect(() => {
+    if (!videoRef?.current) return;
+    videoRef.current.volume = volume;
+  }, [volume, videoRef]);
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    setVolume(Number(e.target.value));
+  };
+
+  const handleIconClick = (e: React.MouseEvent<SVGSVGElement>) => {
+    e.stopPropagation();
+    setVolume(volume === 0 ? 1 : 0);
+  };
+
+  return (
+    <div className="cursor-pointer flex gap-4 pl-3">
+      {volume > 0 ? (
+        <Volume2 className="cursor-pointer" onClick={handleIconClick} />
+      ) : (
+        <VolumeX className="cursor-pointer" onClick={handleIconClick} />
+      )}
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.01"
+        value={volume}
+        onChange={handleVolumeChange}
+        className="appearance-none bg-transparent [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-zinc-300 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[10px] [&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-zinc-700 [&::-webkit-slider-thumb]:p-1"
+        aria-label="Volume control"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+};

--- a/packages/web/src/components/video/error.tsx
+++ b/packages/web/src/components/video/error.tsx
@@ -1,0 +1,16 @@
+import { Layout } from "~/components/video/layout";
+
+interface Props {
+  message: string;
+}
+
+export const Error = (props: Props) => {
+  return (
+    <Layout className="text-center">
+      <div>
+        <h1 className="text-6xl pb-4">Video Player Error</h1>
+        <p>Message: {props.message}</p>
+      </div>
+    </Layout>
+  );
+};

--- a/packages/web/src/components/video/index.ts
+++ b/packages/web/src/components/video/index.ts
@@ -1,0 +1,3 @@
+export * from "./player";
+export * from "./layout";
+export * from "./error";

--- a/packages/web/src/components/video/index.ts
+++ b/packages/web/src/components/video/index.ts
@@ -1,3 +1,4 @@
-export * from "./player";
-export * from "./layout";
+export * from "./controls";
 export * from "./error";
+export * from "./layout";
+export * from "./player";

--- a/packages/web/src/components/video/layout.tsx
+++ b/packages/web/src/components/video/layout.tsx
@@ -1,0 +1,19 @@
+import { cn } from "~/lib";
+
+interface Props {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Layout = (props: Props) => {
+  return (
+    <div
+      className={cn(
+        "w-screen h-screen flex items-center justify-center bg-black",
+        props.className,
+      )}
+    >
+      {props.children}
+    </div>
+  );
+};

--- a/packages/web/src/components/video/layout.tsx
+++ b/packages/web/src/components/video/layout.tsx
@@ -1,3 +1,4 @@
+import { useVideoContext } from "~/providers";
 import { cn } from "~/lib";
 
 interface Props {
@@ -6,8 +7,11 @@ interface Props {
 }
 
 export const Layout = (props: Props) => {
+  const { layoutRef } = useVideoContext();
+
   return (
     <div
+      ref={layoutRef}
       className={cn(
         "w-screen h-screen flex items-center justify-center bg-black",
         props.className,

--- a/packages/web/src/components/video/player.tsx
+++ b/packages/web/src/components/video/player.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Hls from "hls.js";
+import { useVideoContext } from "~/providers";
 import { Video } from "~/components";
 import { cn } from "~/lib";
 
@@ -10,7 +11,7 @@ interface Props {
 }
 
 export const Player = (props: Props) => {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const { videoRef } = useVideoContext();
   const hlsRef = useRef<Hls | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -21,7 +22,7 @@ export const Player = (props: Props) => {
   };
 
   useEffect(() => {
-    if (!videoRef.current) return;
+    if (!videoRef?.current) return;
 
     const video = videoRef.current;
 
@@ -40,7 +41,7 @@ export const Player = (props: Props) => {
 
       hls.on(Hls.Events.LEVEL_SWITCHED, (event, data) => {
         const level = hls.levels[data.level];
-        console.log(`Level switched: ${level.width}x${level.height}`);
+        console.log(`Resolution changed: ${level.width}x${level.height}`);
       });
     } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
       video.src = props.src;
@@ -74,11 +75,10 @@ export const Player = (props: Props) => {
           <p>Loading...</p>
         </div>
       )}
-      <video
-        ref={videoRef}
-        controls
-        className={cn("w-full h-full", loading && "hidden")}
-      />
+      <div className={cn("relative w-full h-full", loading && "hidden")}>
+        <Video.Controls />
+        <video ref={videoRef} className="w-full h-full" />
+      </div>
     </Video.Layout>
   );
 };

--- a/packages/web/src/components/video/player.tsx
+++ b/packages/web/src/components/video/player.tsx
@@ -1,73 +1,17 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import Hls from "hls.js";
 import { useVideoContext } from "~/providers";
 import { Video } from "~/components";
 import { cn } from "~/lib";
 
-interface Props {
-  src: string;
-}
+export const Player = () => {
+  const { videoRef, streamLoading, streamError } = useVideoContext();
 
-export const Player = (props: Props) => {
-  const { videoRef } = useVideoContext();
-  const hlsRef = useRef<Hls | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const errorHandler = (message: string) => {
-    console.error(message);
-    setError(message);
-  };
-
-  useEffect(() => {
-    if (!videoRef?.current) return;
-
-    const video = videoRef.current;
-
-    if (Hls.isSupported()) {
-      const hls = new Hls();
-      hlsRef.current = hls;
-      hls.loadSource(props.src);
-      hls.attachMedia(video);
-      hls.on(Hls.Events.ERROR, (_, data) =>
-        errorHandler(`${data.type}, ${data.details}`),
-      );
-
-      hls.on(Hls.Events.MANIFEST_PARSED, () => {
-        setLoading(false);
-      });
-
-      hls.on(Hls.Events.LEVEL_SWITCHED, (event, data) => {
-        const level = hls.levels[data.level];
-        console.log(`Resolution changed: ${level.width}x${level.height}`);
-      });
-    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
-      video.src = props.src;
-      video.addEventListener("loadedmetadata", () => {
-        video.play().catch((error) => errorHandler(error.message));
-      });
-    }
-
-    video.addEventListener("error", () => {
-      const errorMessage = video.error
-        ? `Video element error: ${video.error.code}`
-        : "Unknown video element error";
-      errorHandler(errorMessage);
-    });
-
-    return () => {
-      if (hlsRef.current) hlsRef.current.destroy();
-      video.removeEventListener("error", () => {});
-    };
-  }, [props.src]);
-
-  if (error) return <Video.Error message={error} />;
+  if (streamError) return <Video.Error message={streamError} />;
 
   return (
     <Video.Layout>
-      {loading && (
+      {streamLoading && (
         <div className="flex flex-col items-center gap-4">
           <div className="bg-white rounded-full w-12 h-12 flex animate-spin">
             <div className="bg-black w-11 h-11 rounded-full" />
@@ -75,7 +19,7 @@ export const Player = (props: Props) => {
           <p>Loading...</p>
         </div>
       )}
-      <div className={cn("relative w-full h-full", loading && "hidden")}>
+      <div className={cn("relative w-full h-full", streamLoading && "hidden")}>
         <Video.Controls />
         <video ref={videoRef} className="w-full h-full" />
       </div>

--- a/packages/web/src/components/video/player.tsx
+++ b/packages/web/src/components/video/player.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Hls from "hls.js";
+import { Video } from "~/components";
+import { cn } from "~/lib";
+
+interface Props {
+  src: string;
+}
+
+export const Player = (props: Props) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const errorHandler = (message: string) => {
+    console.error(message);
+    setError(message);
+  };
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+
+    const video = videoRef.current;
+
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hlsRef.current = hls;
+      hls.loadSource(props.src);
+      hls.attachMedia(video);
+      hls.on(Hls.Events.ERROR, (_, data) =>
+        errorHandler(`${data.type}, ${data.details}`),
+      );
+
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        setLoading(false);
+      });
+
+      hls.on(Hls.Events.LEVEL_SWITCHED, (event, data) => {
+        const level = hls.levels[data.level];
+        console.log(`Level switched: ${level.width}x${level.height}`);
+      });
+    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = props.src;
+      video.addEventListener("loadedmetadata", () => {
+        video.play().catch((error) => errorHandler(error.message));
+      });
+    }
+
+    video.addEventListener("error", () => {
+      const errorMessage = video.error
+        ? `Video element error: ${video.error.code}`
+        : "Unknown video element error";
+      errorHandler(errorMessage);
+    });
+
+    return () => {
+      if (hlsRef.current) hlsRef.current.destroy();
+      video.removeEventListener("error", () => {});
+    };
+  }, [props.src]);
+
+  if (error) return <Video.Error message={error} />;
+
+  return (
+    <Video.Layout>
+      {loading && (
+        <div className="flex flex-col items-center gap-4">
+          <div className="bg-white rounded-full w-12 h-12 flex animate-spin">
+            <div className="bg-black w-11 h-11 rounded-full" />
+          </div>
+          <p>Loading...</p>
+        </div>
+      )}
+      <video
+        ref={videoRef}
+        controls
+        className={cn("w-full h-full", loading && "hidden")}
+      />
+    </Video.Layout>
+  );
+};

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
- 
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/packages/web/src/providers/index.ts
+++ b/packages/web/src/providers/index.ts
@@ -1,1 +1,2 @@
 export * from "./theme";
+export * from "./video";

--- a/packages/web/src/providers/video.tsx
+++ b/packages/web/src/providers/video.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { createContext, useContext, useRef } from "react";
+
+interface Context {
+  videoRef: React.RefObject<HTMLVideoElement> | null;
+  layoutRef: React.RefObject<HTMLDivElement> | null;
+}
+
+const VideoContext = createContext<Context>({
+  videoRef: null,
+  layoutRef: null,
+});
+
+export const VideoProvider = ({ children }: { children: React.ReactNode }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const layoutRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <VideoContext.Provider value={{ videoRef, layoutRef }}>
+      {children}
+    </VideoContext.Provider>
+  );
+};
+
+export const useVideoContext = () => {
+  return useContext(VideoContext);
+};

--- a/packages/web/src/providers/video.tsx
+++ b/packages/web/src/providers/video.tsx
@@ -1,23 +1,314 @@
 "use client";
 
-import React, { createContext, useContext, useRef } from "react";
+import React, {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  useEffect,
+  type MouseEvent,
+  type ChangeEvent,
+} from "react";
+import { useLocalStorage } from "react-use";
+import Hls from "hls.js";
 
 interface Context {
   videoRef: React.RefObject<HTMLVideoElement> | null;
   layoutRef: React.RefObject<HTMLDivElement> | null;
+  isActive: boolean;
+  isFullscreen: boolean;
+  streamSource: string | null;
+  streamLoading: boolean;
+  streamError: string | null;
+  streamPaused: boolean;
+  streamCurrentTime: number;
+  streamCurrentPercent: number;
+  streamBufferPercent: number;
+  streamTotalTime: number;
+  getStreamVolume: () => number;
+  togglePlayPause: (e: MouseEvent<HTMLButtonElement>) => void;
+  toggleFullscreen: (e: MouseEvent<HTMLButtonElement>) => void;
+  toggleVolume: (e: MouseEvent<HTMLButtonElement>) => void;
+  changeVolume: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const VideoContext = createContext<Context>({
   videoRef: null,
   layoutRef: null,
+  isActive: true,
+  isFullscreen: false,
+  streamSource: null,
+  streamLoading: true,
+  streamError: null,
+  streamPaused: true,
+  streamCurrentTime: 0,
+  streamCurrentPercent: 0,
+  streamBufferPercent: 0,
+  streamTotalTime: 0,
+  getStreamVolume: () => 1,
+  togglePlayPause: (e: MouseEvent<HTMLButtonElement>) => {},
+  toggleFullscreen: (e: MouseEvent<HTMLButtonElement>) => {},
+  toggleVolume: (e: MouseEvent<HTMLButtonElement>) => {},
+  changeVolume: (e: ChangeEvent<HTMLInputElement>) => {},
 });
 
-export const VideoProvider = ({ children }: { children: React.ReactNode }) => {
+export const VideoProvider = ({
+  children,
+  src,
+}: {
+  children: React.ReactNode;
+  src: string;
+}) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const layoutRef = useRef<HTMLDivElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [isActive, setIsActive] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [streamLoading, setStreamLoading] = useState(true);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [streamPaused, setStreamPaused] = useState(true);
+  const [streamCurrentTime, setStreamCurrentTime] = useState(0);
+  const [streamCurrentPercent, setStreamCurrentPercent] = useState(0);
+  const [streamBufferPercent, setStreamBufferPercent] = useState(0);
+  const [streamTotalTime, setStreamTotalTime] = useState(0);
+  const [streamVolume, setStreamVolume] = useLocalStorage(
+    "zms-stream-volume",
+    1,
+  );
+
+  // ==============================
+  // Calculate inactivity
+  // ==============================
+  let inactivityTimer: NodeJS.Timeout;
+  const resetInactivityTimer = () => {
+    clearTimeout(inactivityTimer);
+    setIsActive(true);
+    inactivityTimer = setTimeout(() => setIsActive(false), 2000);
+  };
+
+  useEffect(() => {
+    const events = [
+      "mousemove",
+      "keydown",
+      "mousedown",
+      "touchstart",
+      "scroll",
+    ];
+
+    events.forEach((event) =>
+      window.addEventListener(event, resetInactivityTimer),
+    );
+    resetInactivityTimer();
+
+    return () => {
+      clearTimeout(inactivityTimer);
+      events.forEach((event) =>
+        window.removeEventListener(event, resetInactivityTimer),
+      );
+    };
+  }, []);
+
+  // ==============================
+  // Streaming
+  // ==============================
+  const handleStreamError = (message: string) => {
+    console.error(message);
+    setStreamError(message);
+  };
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+    const video = videoRef.current;
+
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hlsRef.current = hls;
+      hls.loadSource(src);
+      hls.attachMedia(video);
+      hls.on(Hls.Events.ERROR, (_, data) =>
+        handleStreamError(`${data.type}, ${data.details}`),
+      );
+
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        setStreamLoading(false);
+      });
+
+      hls.on(Hls.Events.LEVEL_SWITCHED, (event, data) => {
+        const level = hls.levels[data.level];
+        console.log(`Resolution changed: ${level.width}x${level.height}`);
+      });
+    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = src;
+      video.addEventListener("loadedmetadata", () => {
+        video.play().catch((error) => handleStreamError(error.message));
+      });
+    }
+
+    video.addEventListener("error", () => {
+      const errorMessage = video.error
+        ? `Video element error: ${video.error.code}`
+        : "Unknown video element error";
+      handleStreamError(errorMessage);
+    });
+
+    return () => {
+      if (hlsRef.current) hlsRef.current.destroy();
+      video.removeEventListener("error", () => {});
+    };
+  }, [src]);
+
+  // ==============================
+  // Play / Pause control
+  // ==============================
+  const togglePlayPause = () => {
+    if (!videoRef.current) return;
+    const video = videoRef.current;
+
+    if (video.paused) {
+      video.play();
+      setStreamPaused(false);
+    } else {
+      video.pause();
+      setStreamPaused(true);
+    }
+  };
+
+  // ==============================
+  // Scrub control
+  // ==============================
+  const offsetVideoProgress = (offsetSeconds: number) => {
+    if (!videoRef.current) return;
+    const video = videoRef.current;
+
+    video.currentTime = video.currentTime + offsetSeconds;
+  };
+
+  // ==============================
+  // Shortcuts
+  // ==============================
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      switch (event.code) {
+        case "Space":
+          event.preventDefault();
+          togglePlayPause();
+          break;
+        case "ArrowLeft":
+          event.preventDefault();
+          offsetVideoProgress(-5);
+          break;
+        case "ArrowRight":
+          event.preventDefault();
+          offsetVideoProgress(5);
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  // ==============================
+  // Fullscreen control
+  // ==============================
+  const toggleFullscreen = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    if (!layoutRef.current) return;
+    const layout = layoutRef.current;
+
+    try {
+      if (!document.fullscreenElement) layout.requestFullscreen();
+      else {
+        if (document.exitFullscreen) document.exitFullscreen();
+      }
+
+      setIsFullscreen((v) => !v);
+    } catch (e) {
+      console.error(`Unable to toggle fullscreen: ${e}`);
+    }
+  };
+
+  // ==============================
+  // Timecodes / Progress control
+  // ==============================
+  useEffect(() => {
+    if (!videoRef.current) return;
+    const video = videoRef.current;
+
+    const updateProgress = () => {
+      setStreamCurrentTime(video.currentTime);
+      setStreamCurrentPercent((video.currentTime / video.duration) * 100);
+      setStreamTotalTime(video.duration);
+
+      const bufferedRanges = video.buffered;
+      let maxBufferedEnd = 0;
+
+      for (let i = 0; i < bufferedRanges.length; i++) {
+        if (bufferedRanges.end(i) > maxBufferedEnd) {
+          maxBufferedEnd = bufferedRanges.end(i);
+        }
+      }
+
+      setStreamBufferPercent((maxBufferedEnd / video.duration) * 100);
+    };
+
+    video.addEventListener("timeupdate", updateProgress);
+
+    return () => {
+      if (video) video.removeEventListener("timeupdate", updateProgress);
+    };
+  }, [videoRef]);
+
+  // ==============================
+  // Volume control
+  // ==============================
+  const getStreamVolume = () => {
+    return streamVolume ?? 1;
+  };
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+    const video = videoRef.current;
+
+    video.volume = getStreamVolume();
+  }, [streamVolume, videoRef]);
+
+  const toggleVolume = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setStreamVolume(getStreamVolume() === 0 ? 1 : 0);
+  };
+
+  const changeVolume = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    setStreamVolume(Number(e.target.value));
+  };
 
   return (
-    <VideoContext.Provider value={{ videoRef, layoutRef }}>
+    <VideoContext.Provider
+      value={{
+        videoRef,
+        layoutRef,
+        isActive,
+        isFullscreen,
+        streamSource: src,
+        streamLoading,
+        streamError,
+        streamPaused,
+        streamCurrentTime,
+        streamCurrentPercent,
+        streamBufferPercent,
+        streamTotalTime,
+        getStreamVolume,
+        togglePlayPause,
+        toggleFullscreen,
+        toggleVolume,
+        changeVolume,
+      }}
+    >
       {children}
     </VideoContext.Provider>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      react-use:
+        specifier: ^17.4.2
+        version: 17.4.2(react-dom@18.2.0)(react@18.2.0)
       tailwind-merge:
         specifier: ^1.14.0
         version: 1.14.0
@@ -1338,6 +1341,10 @@ packages:
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
     dev: false
 
+  /@types/js-cookie@2.2.7:
+    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
+    dev: false
+
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
@@ -1642,6 +1649,10 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
     dev: true
+
+  /@xobotyi/scrollbar-width@1.9.5:
+    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
+    dev: false
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -2276,6 +2287,12 @@ packages:
       is-what: 4.1.16
     dev: true
 
+  /copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+    dependencies:
+      toggle-selection: 1.0.6
+    dev: false
+
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -2291,6 +2308,20 @@ packages:
       type-fest: 1.4.0
     dev: false
 
+  /css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
+    dependencies:
+      hyphenate-style-name: 1.0.4
+    dev: false
+
+  /css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2298,7 +2329,6 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: true
 
   /d@1.0.1:
     resolution: {integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==}
@@ -2623,6 +2653,12 @@ packages:
   /env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
+    dependencies:
+      stackframe: 1.3.4
     dev: false
 
   /es-abstract@1.22.3:
@@ -3267,6 +3303,18 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-loops@1.1.3:
+    resolution: {integrity: sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==}
+    dev: false
+
+  /fast-shallow-equal@1.0.0:
+    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
+    dev: false
+
+  /fastest-stable-stringify@2.0.2:
+    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
+    dev: false
+
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
@@ -3697,6 +3745,10 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: false
 
+  /hyphenate-style-name@1.0.4:
+    resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
+    dev: false
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3744,6 +3796,13 @@ packages:
   /ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /inline-style-prefixer@7.0.0:
+    resolution: {integrity: sha512-I7GEdScunP1dQ6IM2mQWh6v0mOYdYmH3Bp31UecKdrcUgcURTcctSe1IECdUznSHKSmsHtjrT3CwCPI1pyxfUQ==}
+    dependencies:
+      css-in-js-utils: 3.1.0
+      fast-loops: 1.1.3
     dev: false
 
   /inquirer-autocomplete-prompt@3.0.1(inquirer@9.2.12):
@@ -4068,6 +4127,10 @@ packages:
     resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
     dev: false
 
+  /js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4289,6 +4352,10 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
+  /mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
+
   /memoizee@0.4.15:
     resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
     dependencies:
@@ -4423,6 +4490,24 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  /nano-css@5.6.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-T2Mhc//CepkTa3X4pUhKgbEheJHYAxD0VptuqFhDbGMUWVV2m+lkNiW/Ieuj35wrfC8Zm0l7HvssQh7zcEttSw==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      css-tree: 1.1.3
+      csstype: 3.1.3
+      fastest-stable-stringify: 2.0.2
+      inline-style-prefixer: 7.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      rtl-css-js: 1.16.1
+      stacktrace-js: 2.0.2
+      stylis: 4.3.0
+    dev: false
 
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -5133,6 +5218,40 @@ packages:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
 
+  /react-universal-interface@0.6.2(react@18.2.0)(tslib@2.6.2):
+    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
+    peerDependencies:
+      react: '*'
+      tslib: '*'
+    dependencies:
+      react: 18.2.0
+      tslib: 2.6.2
+    dev: false
+
+  /react-use@17.4.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1jPtmWLD8OJJNYCdYLJEH/HM+bPDfJuyGwCYeJFgPmWY8ttwpgZnW5QnzgM55CYUByUiTjHxsGOnEpLl6yQaoQ==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      '@types/js-cookie': 2.2.7
+      '@xobotyi/scrollbar-width': 1.9.5
+      copy-to-clipboard: 3.3.3
+      fast-deep-equal: 3.1.3
+      fast-shallow-equal: 1.0.0
+      js-cookie: 2.2.1
+      nano-css: 5.6.1(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-universal-interface: 0.6.2(react@18.2.0)(tslib@2.6.2)
+      resize-observer-polyfill: 1.5.1
+      screenfull: 5.2.0
+      set-harmonic-interval: 1.0.1
+      throttle-debounce: 3.0.1
+      ts-easing: 0.2.0
+      tslib: 2.6.2
+    dev: false
+
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -5200,6 +5319,10 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /resize-observer-polyfill@1.5.1:
+    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
     dev: false
 
   /resolve-alpn@1.2.1:
@@ -5291,6 +5414,12 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
+  /rtl-css-js@1.16.1:
+    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
+    dependencies:
+      '@babel/runtime': 7.23.5
+    dev: false
+
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -5352,6 +5481,11 @@ packages:
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: true
 
+  /screenfull@5.2.0:
+    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
@@ -5402,6 +5536,11 @@ packages:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.1
     dev: true
+
+  /set-harmonic-interval@1.0.1:
+    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
+    engines: {node: '>=6.9'}
+    dev: false
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5483,6 +5622,11 @@ packages:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  /source-map@0.5.6:
+    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5491,6 +5635,31 @@ packages:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
+
+  /stack-generator@2.0.10:
+    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
+    dependencies:
+      stackframe: 1.3.4
+    dev: false
+
+  /stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+    dev: false
+
+  /stacktrace-gps@3.1.2:
+    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
+    dependencies:
+      source-map: 0.5.6
+      stackframe: 1.3.4
+    dev: false
+
+  /stacktrace-js@2.0.2:
+    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
+    dependencies:
+      error-stack-parser: 2.1.4
+      stack-generator: 2.0.10
+      stacktrace-gps: 3.1.2
+    dev: false
 
   /stacktracey@2.1.8:
     resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
@@ -5638,6 +5807,10 @@ packages:
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    dev: false
+
+  /stylis@4.3.0:
+    resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
     dev: false
 
   /sucrase@3.34.0:
@@ -5792,6 +5965,11 @@ packages:
     dependencies:
       any-promise: 1.3.0
 
+  /throttle-debounce@3.0.1:
+    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
+    engines: {node: '>=10'}
+    dev: false
+
   /timers-ext@0.1.7:
     resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==}
     dependencies:
@@ -5812,6 +5990,10 @@ packages:
     dependencies:
       is-number: 7.0.0
 
+  /toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+    dev: false
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
@@ -5824,6 +6006,10 @@ packages:
     dependencies:
       typescript: 5.3.3
     dev: true
+
+  /ts-easing@0.2.0:
+    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
+    dev: false
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,15 @@ importers:
         specifier: ^0.5.4
         version: 0.5.9(prettier@3.1.1)
 
+  packages/common:
+    devDependencies:
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.3
+      typescript:
+        specifier: ^4.8.4
+        version: 4.9.5
+
   packages/config-client:
     dependencies:
       zod:
@@ -124,20 +133,48 @@ importers:
         specifier: ^4.8.4
         version: 4.9.5
 
+  packages/transcode:
+    dependencies:
+      '@packages/common':
+        specifier: workspace:*
+        version: link:../common
+      fluent-ffmpeg:
+        specifier: ^2.1.2
+        version: 2.1.2
+    devDependencies:
+      '@types/fluent-ffmpeg':
+        specifier: ^2.1.24
+        version: 2.1.24
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.3
+      typescript:
+        specifier: ^4.8.4
+        version: 4.9.5
+
   packages/web:
     dependencies:
       '@auth/drizzle-adapter':
         specifier: ^0.3.11
         version: 0.3.11
+      '@packages/common':
+        specifier: workspace:*
+        version: link:../common
       '@packages/config-server':
         specifier: workspace:*
         version: link:../config-server
       '@packages/db':
         specifier: workspace:*
         version: link:../db
+      '@packages/transcode':
+        specifier: workspace:*
+        version: link:../transcode
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
+      hls.js:
+        specifier: ^1.4.13
+        version: 1.4.13
       lucide-react:
         specifier: ^0.285.0
         version: 0.285.0(react@18.2.0)
@@ -1291,6 +1328,12 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
+  /@types/fluent-ffmpeg@2.1.24:
+    resolution: {integrity: sha512-g5oQO8Jgi2kFS3tTub7wLvfLztr1s8tdXmRd8PiL/hLMLzTIAyMR2sANkTggM/rdEDAg3d63nYRRVepwBiCw5A==}
+    dependencies:
+      '@types/node': 20.10.4
+    dev: true
+
   /@types/http-cache-semantics@4.0.4:
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
     dev: false
@@ -1836,6 +1879,10 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.6.2
+    dev: false
+
+  /async@3.2.5:
+    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
     dev: false
 
   /asynciterator.prototype@1.0.0:
@@ -3278,6 +3325,14 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
+  /fluent-ffmpeg@2.1.2:
+    resolution: {integrity: sha512-IZTB4kq5GK0DPp7sGQ0q/BWurGHffRtQQwVkiqDgeO6wYJLLV5ZhgNOQ65loZxxuPMKZKZcICCUnaGtlxBiR0Q==}
+    engines: {node: '>=0.8.0'}
+    dependencies:
+      async: 3.2.5
+      which: 1.3.1
+    dev: false
+
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -3600,6 +3655,10 @@ packages:
   /heap@0.2.7:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: true
+
+  /hls.js@1.4.13:
+    resolution: {integrity: sha512-7QGXXS0u/vu0mQqNPRBKR31ru4BLVabVSOnGaXoQZhMRNbfCNTPNJk9ToC0pzvRUfLK/71QjhQO2wdHrgbKeKg==}
+    dev: false
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -6156,6 +6215,13 @@ packages:
       gopd: 1.0.1
       has-tostringtag: 1.0.0
     dev: true
+
+  /which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
 
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       hls.js:
         specifier: ^1.4.13
         version: 1.4.13
+      lodash.throttle:
+        specifier: ^4.1.1
+        version: 4.1.1
       lucide-react:
         specifier: ^0.285.0
         version: 0.285.0(react@18.2.0)
@@ -206,6 +209,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^14.0.4
         version: 14.0.4
+      '@types/lodash.throttle':
+        specifier: ^4.1.9
+        version: 4.1.9
       '@types/node':
         specifier: ^20
         version: 20.10.4
@@ -1351,6 +1357,16 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash.throttle@4.1.9:
+    resolution: {integrity: sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==}
+    dependencies:
+      '@types/lodash': 4.14.202
+    dev: true
+
+  /@types/lodash@4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
     dev: true
 
   /@types/node-fetch@2.6.9:
@@ -4288,7 +4304,6 @@ packages:
 
   /lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-    dev: true
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}


### PR DESCRIPTION
This pr introduces the first version of transcoding logic with video playback.

We are using ffmpeg to do the transcoding to HLS format. HLS allows us to stream the video over http in segments, which will provide better playback performance than vanilla html video solutions. 

To test this pr: 

- Make sure ffmpeg is installed on your machine. On MacOS, this can be done with homebrew: `brew install ffmpeg`
- Add your video file to `media/movies/example.mp4`
- Navigate to `packages/transcode/src/index.ts` and reference your video file `media/movies/example.mp4` in `pipeline()`
- Run the script `pnpm esno packages/tracnsode/src/index.ts`
- Start the web server `pnpm dev`
- Navigate to `http://localhost:3000/movies/play/example.mp4`

I've made the transcoding logic asynchronous, which means that we will create the HLS playlists in this order: 360p > 720p > 1080p. 

I've made each playlist available at the start of the transcoding process. This allows for immediate video playback at 360p and means we're effectively "live transcoding" the video (only applicable if playback is requested immediately before transcoding is finished). 

Once transcoding is finished, the highest quality is automatically played based on the client's available bandwidth. 

I have also started the basic custom UI for the video player. This includes: 
- progress bar with buffer indicator
- volume / mute control
- timecodes 
- play/pause control and indicators 
- fullscreen control