### PR TITLE
💚 docker CI build fixes

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check Out
         uses: actions/checkout@v4

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,4 +33,4 @@ jobs:
           file: Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}/zms:latest
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,5 +32,5 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}/zms:latest
+          tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
This pr fixes some issues with our CI: 

- Docker image URI was incorrect
- `node-gyp` (dependency) does not support building on linux/arm/v7, so that was removed 
- Granted additional required permissions to the job: 

```yaml
    permissions:
      contents: read
      packages: write
```

I'm going to merge this immediately, as our CI currently does not work - this should fix it. 